### PR TITLE
Roche_Error inherits from std::runtime_error

### DIFF
--- a/include/trm/roche.h
+++ b/include/trm/roche.h
@@ -4,6 +4,8 @@
 //! \file
 
 #include <string>
+#include <exception>
+#include <stdexcept>
 #include "trm/subs.h"
 #include "trm/vec3.h"
 
@@ -32,16 +34,16 @@ namespace Roche {
     //! An exception class.
 
     /** Roche::Roche_Error is the error class for the Roche programs.
-     * It is inherited from the standard string class.
+     * It is inherited from the standard runtime_error class.
      */
-    class Roche_Error : public std::string {
+    class Roche_Error : public std::runtime_error {
     public:
 
       //! Default constructor
-    Roche_Error() : std::string() {}
+    Roche_Error() : std::runtime_error("") {}
 
       //! Constructor storing a message
-	Roche_Error(const std::string& err) : std::string(err) {}
+	Roche_Error(const std::string& err) : std::runtime_error(err.c_str()) {}
     };
 
     //! Computes L1 point distance from primary

--- a/src/algol.cc
+++ b/src/algol.cc
@@ -144,7 +144,7 @@ int main (int argc, char *argv[]){
 
   catch(const Roche::Roche_Error& err){
     std::cerr << "Roche::Roche_Error exception:" << std::endl;
-    std::cerr << err << std::endl;
+    std::cerr << err.what() << std::endl;
     exit(EXIT_FAILURE);
   }
   catch(const std::string& err){

--- a/src/cphase.cc
+++ b/src/cphase.cc
@@ -101,7 +101,7 @@ int main (int argc, char *argv[]){
 
   catch(const Roche::Roche_Error& err){
     std::cerr << "Roche::Roche_Error exception:" << std::endl;
-    std::cerr << err << std::endl;
+    std::cerr << err.what() << std::endl;
     exit(EXIT_FAILURE);
   }
   catch(const std::string& err){

--- a/src/equalrv.cc
+++ b/src/equalrv.cc
@@ -205,7 +205,7 @@ int main (int argc, char *argv[]){
 
   catch(const Roche::Roche_Error& err){
     std::cerr << "Roche::Roche_Error exception:" << std::endl;
-    std::cerr << err << std::endl;
+    std::cerr << err.what() << std::endl;
     exit(EXIT_FAILURE);
   }
   catch(const std::string& err){

--- a/src/impact.cc
+++ b/src/impact.cc
@@ -93,7 +93,7 @@ int main (int argc, char *argv[]){
 
   catch(const Roche::Roche_Error& err){
     std::cerr << "Roche::Roche_Error exception:" << std::endl;
-    std::cerr << err << std::endl;
+    std::cerr << err.what() << std::endl;
     exit(EXIT_FAILURE);
   }
   catch(const std::string& err){

--- a/src/pcont.cc
+++ b/src/pcont.cc
@@ -101,7 +101,7 @@ int main(){
 	    }
 	}
 	catch(Roche::Roche_Error err){
-	    std::cerr << "Roche::Roche_Error\n" << err << std::endl;
+	    std::cerr << "Roche::Roche_Error\n" << err.what() << std::endl;
 	}
     }
 }

--- a/src/pphi.cc
+++ b/src/pphi.cc
@@ -81,7 +81,7 @@ int main(){
 
 	}
 	catch(Roche::Roche_Error err){
-	    std::cerr << "Roche::Roche_Error\n" << err << std::endl;
+	    std::cerr << "Roche::Roche_Error\n" << err.what() << std::endl;
 	}
     }
 }

--- a/src/vspace.cc
+++ b/src/vspace.cc
@@ -245,7 +245,7 @@ int main (int argc, char *argv[]){
 
   catch(const Roche::Roche_Error& err){
     std::cerr << "Roche::Roche_Error exception:" << std::endl;
-    std::cerr << err << std::endl;
+    std::cerr << err.what() << std::endl;
     exit(EXIT_FAILURE);
   }
   catch(const std::string& err){


### PR DESCRIPTION
This makes more simple error handling in cython/python modules
